### PR TITLE
Correct julia markdown info string in 03 Data structures.

### DIFF
--- a/introductory-tutorials/intro-to-julia/03. Data structures.ipynb
+++ b/introductory-tutorials/intro-to-julia/03. Data structures.ipynb
@@ -28,7 +28,8 @@
     "\n",
     "Syntax: <br>\n",
     "```julia\n",
-    "(item1, item2, ...)```"
+    "(item1, item2, ...)\n",
+    "```\n"
    ]
   },
   {
@@ -136,7 +137,8 @@
     "\n",
     "Syntax:\n",
     "```julia\n",
-    "Dict(key1 => value1, key2 => value2, ...)```\n",
+    "Dict(key1 => value1, key2 => value2, ...)\n",
+    "```\n",
     "\n",
     "A good example is a contacts list, where we associate names with phone numbers."
    ]
@@ -259,7 +261,8 @@
     "\n",
     "Syntax: <br>\n",
     "```julia\n",
-    "[item1, item2, ...]```\n",
+    "[item1, item2, ...]\n",
+    "```\n",
     "\n",
     "\n",
     "For example, we might create an array to keep track of my friends"


### PR DESCRIPTION
Send the three closing back ticks ``` to a new line to comply with CommonMark.
