### PR TITLE
Add hint in data structures to reference Julia documentation

### DIFF
--- a/.nbexports/introductory-tutorials/intro-to-julia/03. Data structures.jl
+++ b/.nbexports/introductory-tutorials/intro-to-julia/03. Data structures.jl
@@ -302,7 +302,9 @@ fibonacci
 # ------------------------------------------------------------------------------------------
 # #### 3.5
 # Why can we add an integer as a value to `flexible_phonebook` but not `myphonebook`? How
-# could we have initialized `myphonebook` so that it would accept integers as values?
+# could we have initialized `myphonebook` so that it would accept integers as values?  
+# (hint: try using [Julia's documentation for dictionaries](https://docs.julialang.org/en/
+# v1/base/collections/#Dictionaries))
 # ------------------------------------------------------------------------------------------
 
 

--- a/introductory-tutorials/intro-to-julia/03. Data structures.ipynb
+++ b/introductory-tutorials/intro-to-julia/03. Data structures.ipynb
@@ -714,7 +714,7 @@
    "metadata": {},
    "source": [
     "#### 3.5 \n",
-    "Why can we add an integer as a value to `flexible_phonebook` but not `myphonebook`? How could we have initialized `myphonebook` so that it would accept integers as values?"
+    "Why can we add an integer as a value to `flexible_phonebook` but not `myphonebook`? How could we have initialized `myphonebook` so that it would accept integers as values? (hint: try using [Julia's documentation for dictionaries](https://docs.julialang.org/en/v1/base/collections/#Dictionaries))"
    ]
   },
   {
@@ -734,15 +734,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.0.0",
+   "display_name": "Julia 1.4.1",
    "language": "julia",
-   "name": "julia-1.0"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.0.0"
+   "version": "1.4.1"
   }
  },
  "nbformat": 4,

--- a/introductory-tutorials/intro-to-julia/03. Data structures.ipynb
+++ b/introductory-tutorials/intro-to-julia/03. Data structures.ipynb
@@ -734,15 +734,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.4.1",
+   "display_name": "Julia 1.0.0",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.0"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.1"
+   "version": "1.0.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the tutorial it refers to explicit typing for dictionaries, but the declaration is not mentioned within the tutorial. This is fine, but I added a hint to look at the julia documentation to see how to do it. This should also have the benefit of letting users get familiar with documentation to discover more features on their own.