### PR TITLE
Allow running notbooks in binder

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,2 @@
+[compat]
+julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,14 @@
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Interact = "c601a237-2ae4-5e1e-952c-7a85b0c7eef1"
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TextParse = "e0df1984-e451-5cb5-8b61-797a481e67e3"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Interact = "c601a237-2ae4-5e1e-952c-7a85b0c7eef1"
+PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,2 +1,8 @@
+[deps]
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Interact = "c601a237-2ae4-5e1e-952c-7a85b0c7eef1"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Interact = "c601a237-2ae4-5e1e-952c-7a85b0c7eef1"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,24 @@
+jupyter contrib nbextension install --user
+jupyter nbextension enable --py widgetsnbextension
+# jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.38 --minimize=False
+
+# https://binnisb.github.io/blog/datascience/2020/04/02/Plotly-in-lab.html
+# Avoid "JavaScript heap out of memory" errors during extension installation
+# (OS X/Linux)
+export NODE_OPTIONS=--max-old-space-size=4096
+
+# Jupyter widgets extension
+jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
+
+# jupyterlab renderer support
+jupyter labextension install jupyterlab-plotly --no-build
+
+# FigureWidget support
+jupyter labextension install plotlywidget --no-build
+
+# Build extensions (must be done to activate extensions since --no-build is used above)
+jupyter lab build
+
+# Unset NODE_OPTIONS environment variable
+# (OS X/Linux)
+unset NODE_OPTIONS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+webio_jupyter_extension

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 webio_jupyter_extension
-jupyterlab-plotly
+ipywidgets
+jupyter_contrib_nbextensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 webio_jupyter_extension
+jupyterlab-plotly


### PR DESCRIPTION
Binder provides an environment to run Julia notebooks. However, a Project.toml with a julia compat entry is required to provide the Julia kernel with it.

Furthermore, Interactive.jl and plotly  require further jupyter extensions. 