### PR TITLE
Clarify the Euler's Number constant in the sigmoid function example

### DIFF
--- a/introductory-tutorials/broader-topics-and-ecosystem/intro-to-ml/04. Tools - Functions.ipynb
+++ b/introductory-tutorials/broader-topics-and-ecosystem/intro-to-ml/04. Tools - Functions.ipynb
@@ -90,7 +90,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "This syntax says, \"I want to use the variable g to access a function that takes some input called `x` and maps that input to the square of `x`."
+        "This syntax says, \"I want to use the variable `g` to access a function that takes some input called `x` and maps that input to the square of `x`."
       ],
       "metadata": {}
     },
@@ -104,7 +104,8 @@
     {
       "cell_type": "markdown",
       "source": [
-        "A particular function that is used a lot in machine learning is a so-called \"sigmoidal\" function (meaning a function that is S-shaped, i.e. the graph of the function looks like an `S`).\n\nThe sigmoid function that we will use is given the name $\\sigma$, and is defined by the following mathematical expression:\n\n$$\\sigma(x) := \\frac{1}{1 + \\exp(-x)}.$$"
+        "A particular function that is used a lot in machine learning is a so-called \"sigmoidal\" function (meaning a function that is S-shaped, i.e. the graph of the function looks like an `S`).\n\nThe sigmoid function that we will use is given the name $\\sigma$, and is defined by the following mathematical expression:\n\n$$\\sigma(x) := \\frac{1}{1 + e^{-x}}.$$\n",
+        "Where $e$ is a constant knowned as the [Euler's Number](https://en.wikipedia.org/wiki/E_(mathematical_constant)). Type `\\euler<TAB>` to access the constant."
       ],
       "metadata": {}
     },
@@ -112,7 +113,7 @@
       "outputs": [],
       "cell_type": "code",
       "source": [
-        "σ(w*x) = 1/ (1+e^(-w*x))"
+        "σ(w*x) = 1/ (1+ℯ^(-w*x))"
       ],
       "metadata": {},
       "execution_count": null


### PR DESCRIPTION
It is better to be explicit with the Euler's Number in the equation
and add a short explanation and a way to use the constant in Julia
than to use `expr` which is inconsistent with the code that followed.

Also correct 'e' to unicode `e` in the code followed (consider using `expr` here
if it makes the code clearer).

Minor: format `g` function name as code.